### PR TITLE
feat: memory usage improvements

### DIFF
--- a/assets/shaders/voxels.wgsl
+++ b/assets/shaders/voxels.wgsl
@@ -8,15 +8,26 @@ struct Uniforms {
 @group(0) @binding(0)
 var<uniform> uniforms: Uniforms;
 
+@group(1) @binding(0)
+var<uniform> offset: vec2<f32>;
+
+
 struct VertexIn {
-    @location(0) vertex_pos: vec3<f32>,
-    @location(1) texture_id: u32,
+    @location(0) vertex_data: u32,
     @builtin(vertex_index) v_index: u32
 }
 
 struct VertexOut {
     @builtin(position) vertex_pos: vec4<f32>,
     @location(0) tex_coords: vec2<f32>
+}
+
+fn calculate_vertex_coordinates(data: u32) -> vec3<f32> {
+	return vec3<f32>(f32(((data >> 28) & 0xf) | ((((data >> 12) >> 3) & 0x1) << 4)), f32(((data >> 20) & 0xff) | ((((data >> 12) >> 2) & 0x1) << 8)), f32(((data >> 16) & 0xf) | ((((data >> 12) >> 1) & 0x1) << 4)));
+}
+
+fn calculate_vertex_texture(data: u32) -> u32 {
+	return (data & 0xfff);
 }
 
 fn calculate_texture_coordinates(v_index: u32, texture_id: u32) -> vec2<f32> {
@@ -52,8 +63,11 @@ fn calculate_texture_coordinates(v_index: u32, texture_id: u32) -> vec2<f32> {
 @vertex
 fn vs_main(in: VertexIn) -> VertexOut{
     var out: VertexOut;
-    out.vertex_pos = uniforms.proj * uniforms.view * vec4<f32>(in.vertex_pos, 1.0);
-    out.tex_coords = calculate_texture_coordinates(in.v_index, in.texture_id);
+    var pos = calculate_vertex_coordinates(in.vertex_data);
+    pos.x += offset.x * 16;
+    pos.z += offset.y * 16;
+    out.vertex_pos = uniforms.proj * uniforms.view * vec4<f32>(pos, 1.0);
+    out.tex_coords = calculate_texture_coordinates(in.v_index, calculate_vertex_texture(in.vertex_data));
     return out;
 }
 

--- a/explora/src/render/buffer.rs
+++ b/explora/src/render/buffer.rs
@@ -32,6 +32,21 @@ impl<T: Copy + bytemuck::Pod> Buffer<T> {
         }
     }
 
+    /// Creates a new [Buffer] with a given size.
+    pub fn with_size(device: &wgpu::Device, usage: wgpu::BufferUsages, size: u64) -> Self {
+        let descriptor = wgpu::BufferDescriptor {
+            label: Some("Buffer"),
+            usage,
+            mapped_at_creation: false,
+            size,
+        };
+        Self {
+            buf: device.create_buffer(&descriptor),
+            phantom: std::marker::PhantomData,
+            len: size as u32,
+        }
+    }
+
     /// Write data into the buffer.
     ///
     /// If the data is empty it will do nothing to avoid

--- a/explora/src/render/mesh.rs
+++ b/explora/src/render/mesh.rs
@@ -5,17 +5,13 @@ use common::{
 
 use super::{atlas::Atlas, Vertex};
 
-pub fn create_chunk_mesh(chunk: &Chunk, mesh: &mut Vec<Vertex>, pos: Vec2<i32>, atlas: &Atlas) {
+pub fn create_chunk_mesh(chunk: &Chunk, mesh: &mut Vec<Vertex>, _pos: Vec2<i32>, atlas: &Atlas) {
     for x in 0..Chunk::SIZE.x {
         for y in 0..Chunk::SIZE.y {
             for z in 0..Chunk::SIZE.z {
                 let origin = Vec3::new(x, y, z).as_::<i32>();
                 let block = chunk.get(origin).unwrap();
-                let offset = Vec3::new(
-                    pos.x as f32 * Chunk::SIZE.x as f32 + x as f32,
-                    y as f32,
-                    pos.y as f32 * Chunk::SIZE.z as f32 + z as f32,
-                );
+                let offset = Vec3::new(x as f32, y as f32, z as f32);
                 let texture = atlas.block_texture(block);
                 // North
                 if Chunk::out_of_bounds(origin + Vec3::unit_z()) {

--- a/explora/src/render/mod.rs
+++ b/explora/src/render/mod.rs
@@ -54,21 +54,36 @@ impl Uniforms {
 #[repr(C)]
 #[derive(bytemuck::Pod, bytemuck::Zeroable, Clone, Copy)]
 pub struct Vertex {
-    pos: [f32; 3],
-    texture_id: u32,
+    data: u32,
 }
 
 impl Vertex {
     pub fn new(v: Vec3<f32>, texture_id: u32) -> Self {
         Self {
-            pos: v.into_array(),
-            texture_id,
+            data: ((v.x as u32 & 0xf) << 28)
+                | ((v.y as u32 & 0xff) << 20)
+                | ((v.z as u32 & 0xf) << 16)
+                | ((((v.x as u32 & 0x10) >> 4) << 3) << 12)
+                | ((((v.y as u32 & 0x100) >> 8) << 2) << 12)
+                | ((((v.z as u32 & 0x10) >> 4) << 1) << 12)
+                | (texture_id & 0xfff),
         }
     }
 
+    pub fn x(&self) -> f32 {
+        (((self.data >> 28) & 0xf) | ((((self.data >> 12) >> 3) & 0x1) << 4)) as f32
+    }
+
+    pub fn y(&self) -> f32 {
+        (((self.data >> 20) & 0xff) | ((((self.data >> 12) >> 2) & 0x1) << 8)) as f32
+    }
+
+    pub fn z(&self) -> f32 {
+        (((self.data >> 16) & 0xf) | ((((self.data >> 12) >> 1) & 0x1) << 4)) as f32
+    }
+
     pub fn desc<'a>() -> wgpu::VertexBufferLayout<'a> {
-        const ATTRS: [wgpu::VertexAttribute; 2] =
-            wgpu::vertex_attr_array![0 => Float32x3, 1 => Uint32];
+        const ATTRS: [wgpu::VertexAttribute; 1] = wgpu::vertex_attr_array![0 => Uint32];
         wgpu::VertexBufferLayout {
             step_mode: wgpu::VertexStepMode::Vertex,
             attributes: &ATTRS,
@@ -250,10 +265,25 @@ impl Renderer {
                 occlusion_query_set: None,
             });
 
-            self.voxels.draw(&mut render_pass, &self.common_bg);
+            self.voxels
+                .draw(&mut render_pass, &self.common_bg, &self.queue);
         }
 
         self.queue.submit(std::iter::once(encoder.finish()));
         frame.present();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Vertex;
+    use common::math::Vec3;
+
+    #[test]
+    fn vertex() {
+        let v = Vertex::new(Vec3::new(16.0, 256.0, 16.0), 0);
+        assert_eq!(v.x(), 16.0);
+        assert_eq!(v.y(), 256.0);
+        assert_eq!(v.z(), 16.0);
     }
 }

--- a/explora/src/render/voxels.rs
+++ b/explora/src/render/voxels.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 use common::{chunk::Chunk, math::Vec2};
 
 use super::{atlas::Atlas, buffer::Buffer, mesh, texture::Texture, Vertex};
@@ -5,10 +7,19 @@ use super::{atlas::Atlas, buffer::Buffer, mesh, texture::Texture, Vertex};
 pub struct Voxels {
     /// Terrain render pipeline
     render_pipeline: wgpu::RenderPipeline,
-    // /// Terrain geometry
-    chunk_meshes: Vec<Buffer<Vertex>>,
+    /// Terrain geometry
+    chunk_meshes: Vec<(Vec2<i32>, Buffer<Vertex>)>,
     /// Terrain indices
     index_buffer: Buffer<u32>,
+    /// Buffer containing the offset of the currently drawn chunk
+    offset_buffer: Buffer<[f32; 2]>,
+    offset_stride: u32,
+    chunk_bg: wgpu::BindGroup,
+}
+
+pub fn ceil_to_next_multiple(value: u32, step: u32) -> u32 {
+    let divide_and_ceil = value / step + (if value % step == 0 { 0 } else { 1 });
+    return step * divide_and_ceil;
 }
 
 impl Voxels {
@@ -25,9 +36,44 @@ impl Voxels {
             ),
         });
 
+
+        let offset_stride = ceil_to_next_multiple(mem::size_of::<f32>() as u32 * 2, 0x100);
+        let offset_buffer = Buffer::with_size(
+            device,
+            wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            offset_stride as u64 * 9,
+        );
+
+        let chunk_bg_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("Chunk Bind Group Layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: true,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+        });
+
+        let chunk_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Chunk Bind Group"),
+            layout: &chunk_bg_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &offset_buffer.buf,
+                    offset: 0,
+                    size: wgpu::BufferSize::new(mem::size_of::<f32>() as u64 * 2),
+                }),
+            }],
+        });
+
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: None,
-            bind_group_layouts: &[&common_bg_layout],
+            bind_group_layouts: &[&common_bg_layout, &chunk_bg_layout],
             push_constant_ranges: &[],
         });
 
@@ -86,7 +132,10 @@ impl Voxels {
         for (pos, chunk) in chunk_generation {
             let mut chunk_mesh = vec![];
             mesh::create_chunk_mesh(&chunk, &mut chunk_mesh, pos, atlas);
-            chunk_meshes.push(Buffer::new(device, wgpu::BufferUsages::VERTEX, &chunk_mesh));
+            chunk_meshes.push((
+                pos,
+                Buffer::new(device, wgpu::BufferUsages::VERTEX, &chunk_mesh),
+            ));
             vertex_count += chunk_mesh.len() as u32;
         }
 
@@ -100,6 +149,9 @@ impl Voxels {
             render_pipeline,
             chunk_meshes,
             index_buffer,
+            chunk_bg,
+            offset_buffer,
+            offset_stride
         }
     }
 
@@ -107,13 +159,23 @@ impl Voxels {
         &'a mut self,
         frame: &mut wgpu::RenderPass<'a>,
         common_bg: &'a wgpu::BindGroup,
+        queue: &'a wgpu::Queue,
     ) {
         frame.set_pipeline(&self.render_pipeline);
         frame.set_bind_group(0, common_bg, &[]);
         frame.set_index_buffer(self.index_buffer.slice(), wgpu::IndexFormat::Uint32);
+        let mut stride = 0;
         for chunk_mesh in &self.chunk_meshes {
-            frame.set_vertex_buffer(0, chunk_mesh.slice());
-            frame.draw_indexed(0..chunk_mesh.len() / 4 * 6, 0, 0..1);
+            queue.write_buffer(
+                &self.offset_buffer.buf,
+                (stride) as u64,
+                bytemuck::cast_slice(&[chunk_mesh.0.x as f32, chunk_mesh.0.y as f32]),
+            );
+            
+            frame.set_bind_group(1, &self.chunk_bg, &[stride]);
+            frame.set_vertex_buffer(0, chunk_mesh.1.slice());
+            frame.draw_indexed(0..chunk_mesh.1.len() / 4 * 6, 0, 0..1);
+            stride += self.offset_stride;
         }
     }
 }


### PR DESCRIPTION
I reduced the size of the Vertex data structure, by almost 70%.
To do so, I packed all the 3 vertex coordinates plus the texture index in a single 32 bits integer, this limits the chunk size to be precisely 16x256x16.